### PR TITLE
Fix errors while compiling with dub build

### DIFF
--- a/dlib/geometry/triangle.d
+++ b/dlib/geometry/triangle.d
@@ -26,7 +26,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-module dlib.mesh.triangle;
+module dlib.geometry.triangle;
 
 private
 {

--- a/dlib/image/filters/morphology.d
+++ b/dlib/image/filters/morphology.d
@@ -90,14 +90,16 @@ body
 
             auto pix = img[ix, iy];
 
+			auto fpix = ColorRGBAf(pix);
+			auto fresc = ColorRGBAf(resc);
             static if (op == MorphOperation.Dilate)
             {
-                if (ColorRGBAf(pix) > ColorRGBAf(resc)) 
+                if (fpix > fresc)
                     resc = pix;
             }
             static if (op == MorphOperation.Erode)
             {
-                if (ColorRGBAf(pix) < ColorRGBAf(resc)) 
+                if (fpix < fresc) 
                     resc = pix;
             }
         }

--- a/dlib/image/io/png.d
+++ b/dlib/image/io/png.d
@@ -26,7 +26,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-module dlib.image.png;
+module dlib.image.io.png;
 
 private
 {

--- a/dlib/image/io/zstream.d
+++ b/dlib/image/io/zstream.d
@@ -26,7 +26,7 @@ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 */
 
-module dlib.image.zstream;
+module dlib.image.io.zstream;
 
 private
 {

--- a/dlib/image/signal2d.d
+++ b/dlib/image/signal2d.d
@@ -158,6 +158,21 @@ class Signal2D
         
         return res;
     }
+	
+	Signal2D divide(Signal2D img)
+    {
+        assert(img.width == width && img.height == height);
+        
+        Signal2D res = new Signal2D(width, height);
+        res.domain = domain;
+        
+        foreach(i, v; data)
+        {
+            res.data[i] = v / img.data[i];
+        }
+        
+        return res;
+    }
     
     Complex!(float) opIndex(int x, int y)
     {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,16 @@
 {
-    "name": "dlib",
-    "description": "D language utility library",
-    "authors": ["Timur Gafarov"],
-    "homepage": "http://github.com/gecko0307/dlib",
-    "license": "Boost",
-    "sourcePaths": ["dlib"],
+	"description": "D language utility library",
+	"authors": [
+		"Timur Gafarov"
+	],
+	"version": "~master",
+	"license": "Boost",
+	"homepage": "http://github.com/gecko0307/dlib",
+	"name": "dlib",
+	"sourcePaths": [
+		"dlib"
+	],
+	"buildRequirements":[
+	"allowWarnings"
+]
 }


### PR DESCRIPTION
Fix: wrong file names.
Fix: replace LF by CRLF.
Fix: allow warnings in dub config.
Fix: little hack to workaround rvalue refences issue in dlib.image.filters.morphology.
Add: Signal2D.divide(Signal2D img), needs cheking.

Also there are some warnings while compiling which need to be fixed. I have added "allowWarnings" option to dub config to get it compile for now.
