### PR TITLE
Add empty property to Queue, LinkedList.

### DIFF
--- a/dlib/core/linkedlist.d
+++ b/dlib/core/linkedlist.d
@@ -42,6 +42,11 @@ struct LinkedList(T, bool ordered = false)
     LinkedListElement!(T)* tail = null;
 	size_t length = 0;
 
+    @property bool empty()
+    {
+        return length == 0;
+    }
+
     void traverse(void delegate(ref T v, LinkedListElement!(T)* elem) func)
     {
         LinkedListElement!(T)* element = head;

--- a/dlib/core/queue.d
+++ b/dlib/core/queue.d
@@ -40,6 +40,12 @@ struct Queue(T)
     private LinkedList!(T) list;
 
     public:
+
+    @property bool empty()
+    {
+        return list.empty;
+    }
+
     void enqueue(T v)
     {
         list.append(v);
@@ -59,11 +65,16 @@ struct Queue(T)
 unittest
 {
     Queue!int q;
+
+    assert (q.empty);
+
     q.enqueue(50);
     q.enqueue(30);
     q.enqueue(900);
+
     assert (q.dequeue() == 50);
     assert (q.dequeue() == 30);
     assert (q.dequeue() == 900);
+    assert (q.empty);
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
             "excludedSourceFiles": [
                 "dlib/math/matrix2x2.d",
                 "dlib/math/matrix3x3.d",
-                "dlib/math/matrix4x4.d"
+                "dlib/math/matrix4x4.d",
+                "dlib/math/affine_old.d",
+                "dlib/math/matrix_old.d"
             ]
         },
         {


### PR DESCRIPTION
Add empty property to Queue, LinkedList.

Add "dlib/math/affine_old.d", "dlib/math/matrix_old.d" to excludedSourceFiles as they have the same module name as dlib/math/affine.d and dlib/math/matrix.d.
