### PR TITLE
Fix result assigned to parameters in Quaternion.fromEulerAngles.

### DIFF
--- a/dlib/math/quaternion.d
+++ b/dlib/math/quaternion.d
@@ -470,10 +470,10 @@ struct Quaternion(T)
             T sy = sin(z * 0.5);
             T cy = cos(z * 0.5);
 
-            w =  (cy * cp * cr) + (sy * sp * sr);
-            x = -(sy * sp * cr) + (cy * cp * sr);
-            y =  (cy * sp * cr) + (sy * cp * sr);
-            z = -(cy * sp * sr) + (sy * cp * cr);
+            this.w =  (cy * cp * cr) + (sy * sp * sr);
+            this.x = -(sy * sp * cr) + (cy * cp * sr);
+            this.y =  (cy * sp * cr) + (sy * cp * sr);
+            this.z = -(cy * sp * sr) + (sy * cp * cr);
         }
 
        /* 


### PR DESCRIPTION
When given input x:0, y:90, z:0 degrees the result is:
`[nan, nan, nan, 0.707107]`
while expected:
`[0, 0.707107, 0, 0.707107]`

x, y and z were assigned to input parameters instead of struct members.
