### PR TITLE
Fix wrong fseek parameter type error on 64 bit. Fix (T *= float is performing truncating conversion) warning.

### DIFF
--- a/dlib/filesystem/stdfs.d
+++ b/dlib/filesystem/stdfs.d
@@ -70,7 +70,8 @@ class StdInFileStream: InputStream
 
     bool setPosition(StreamPos p)
     {
-        return !fseek(file, cast(fpos_t)p, SEEK_SET);
+        import core.stdc.config : c_long;
+        return !fseek(file, cast(c_long)p, SEEK_SET);
     }
 
     StreamSize size()

--- a/dlib/math/vector.d
+++ b/dlib/math/vector.d
@@ -522,7 +522,7 @@ struct Vector(T, int size)
                 {
                     float coef = 1.0 / sqrt(cast(float)lensqr);
                     foreach (ref component; arrayof) 
-                        component *= coef;
+                        component = cast(T)(component * coef);
                 }
             }
         }


### PR DESCRIPTION
Fixes 
`dlib\filesystem\stdfs.d(73,22): Error: function core.stdc.stdio.fseek (shared(_iobuf)* stream, int offset, int whence) is not callable using argument types (shared(_iobuf)*, long, int)` on 64 bit
and
`dlib\math\vector.d(525,35): Warning: int *= float is performing truncating conversion`
`dlib\math\vector.d(525,35): Warning: uint *= float is performing truncating conversion`
...