### PR TITLE
Unittests for utf8 and lexer. Fix decoding of 4 byte utf8 sequences

### DIFF
--- a/dlib/text/lexer.d
+++ b/dlib/text/lexer.d
@@ -54,7 +54,7 @@ bool buffEq(dchar[] b1, dchar[] b2)
     return true;
 }
 
-/*
+/**
  * General-purpose lexical analyzer.
  * Breaks the input string to a stream of lexemes according to a given dictionary.
  * Assumes UTF-8 input.
@@ -249,5 +249,30 @@ class Lexer
 
         return output;
     }
+}
+
+///
+unittest
+{
+    string[] delims = ["(", ")", ";", " ", "{", "}", ".", "\n", "\r", "=", "++", "<"];
+    auto input = "for (int i=0; i<arr.length; ++i)\r\n{doThing();}\n";
+    auto lexer = new Lexer(input, delims);
+    
+    import std.utf : toUTF8;
+    
+    string[] arr;
+    while(true) {
+        auto lexeme = lexer.getLexeme();
+        if(lexeme.length == 0) {
+            break;
+        }
+        arr ~= lexeme.toUTF8;
+        Delete(lexeme);
+    }
+    assert(arr == ["for", " ", "(", "int", " ", "i", "=", "0", ";", " ", "i", "<", "arr", ".", "length", ";", " ", "++", "i", ")", "\n", "{", "doThing", "(", ")", ";", "}", "\n" ]);
+    
+    input = "";
+    lexer = new Lexer(input, delims);
+    assert(lexer.getLexeme().length == 0);
 }
 

--- a/dlib/text/utils.d
+++ b/dlib/text/utils.d
@@ -30,7 +30,7 @@ module dlib.text.utils;
 
 import dlib.core.memory;
 
-// Make an unmanaged copy of a string
+/// Make an unmanaged copy of a string
 T[] copy(T)(T[] b)
 {
     auto res = New!(T[])(b.length);
@@ -39,7 +39,16 @@ T[] copy(T)(T[] b)
     return res;
 }
 
-// Concatenates two strings to a new unmanaged string
+///
+unittest
+{
+    auto str = "hello".dup;
+    auto c = copy(str);
+    assert(c == str);
+    Delete(c);
+}
+
+/// Concatenates two strings to a new unmanaged string
 string catStr(string s1, string s2)
 {
     char[] buffer = New!(char[])(s1.length + s2.length);
@@ -53,4 +62,15 @@ string catStr(string s1, string s2)
         buffer[i+j] = s2[j];
     }
     return cast(string)buffer;
+}
+
+///
+unittest
+{
+    auto str1 = "hello";
+    auto str2 = " world";
+    
+    auto cat = catStr(str1, str2);
+    assert(cat == "hello world");
+    Delete(cat);
 }


### PR DESCRIPTION
This adds unittests and some ddoc comments for utf8 and lexer.

For some reason UTF8Decoder used addition of 65536 to the result of decoding 4-byte sequences. I don't why it's here, code looks right without it, so I removed this addition. Tested on this symbol http://www.fileformat.info/info/unicode/char/10348/index.htm