### PR TITLE
Add unittests for ArrayStream. Fix 'size' member function

### DIFF
--- a/dlib/core/stream.d
+++ b/dlib/core/stream.d
@@ -210,6 +210,10 @@ class ArrayStream : InputStream {
         this.data = data;
     }
     
+    this(ubyte[] data) {
+        this(data, data.length);
+    }
+    
     override void close() {
         this.pos = 0;
         this.size_ = 0;
@@ -249,7 +253,7 @@ class ArrayStream : InputStream {
     }
     
     override StreamSize size() {
-        return size;
+        return size_;
     }
 
     //mixin ManualModeImpl;
@@ -258,4 +262,39 @@ class ArrayStream : InputStream {
     private:
     size_t pos = 0, size_ = 0;
     ubyte[] data;       // data.length is capacity
+}
+
+///
+unittest
+{
+    ubyte[] arr = [23,13,42,71,0,1,1,2,3,5,8];
+    
+    auto stream = new ArrayStream(arr);
+    assert(stream.size() == arr.length);
+    
+    ubyte[4] buf;
+    assert(stream.readBytes(buf.ptr, buf.length) == buf.length);
+    assert(buf == [23,13,42,71]);
+    assert(stream.getPosition() == buf.length);
+    
+    assert(stream.setPosition(6));
+    assert(stream.getPosition == 6);
+    assert(stream.readBytes(buf.ptr, buf.length) == buf.length);
+    assert(buf == [1,2,3,5]);
+    
+    assert(stream.readBytes(buf.ptr, buf.length) == 1);
+    assert(buf[0] == 8);
+    assert(!stream.readable);
+    
+    stream.setPosition(1);
+    assert(stream.readable);
+    stream.seek(4);
+    assert(stream.readBytes(buf.ptr, buf.length) == buf.length);
+    assert(buf == [1,1,2,3]);
+    
+    assert(stream.setPosition(arr.length));
+    assert(!stream.setPosition(arr.length+1));
+    
+    stream.close();
+    assert(!stream.readable);
 }


### PR DESCRIPTION
Unittests for ArrayStream.
Fix recursion in ArrayStream.size member function.
Add constructor that accepts slice.