### PR TITLE
dmd 2.072.0 changes

### DIFF
--- a/dlib/async/watcher.d
+++ b/dlib/async/watcher.d
@@ -197,7 +197,7 @@ class IOWatcher : ConnectionWatcher
      *
      * Returns: $(D_KEYWORD this).
      */
-    IOWatcher opCall(StreamTransport transport, Protocol protocol) pure nothrow @safe @nogc
+    IOWatcher opCall(StreamTransport transport, Protocol protocol) pure nothrow @nogc
     in
     {
         assert(transport !is null);

--- a/dlib/filesystem/local.d
+++ b/dlib/filesystem/local.d
@@ -429,6 +429,7 @@ unittest
 
         SysTime modificationTime, accessTime;
         expected[i].getTimes(accessTime, modificationTime);
+        modificationTime.fracSecs = Duration.zero;
         assert(modificationTime ==  stat_.modificationTimestamp);
 
         ++i;

--- a/dlib/filesystem/stdposixdir.d
+++ b/dlib/filesystem/stdposixdir.d
@@ -105,7 +105,7 @@ class StdPosixDirEntryRange: InputRange!(DirEntry)
         return _empty;
     }
 
-    int opApply(int delegate(DirEntry) dg)
+    int opApply(scope int delegate(DirEntry) dg)
     {
         while(!_empty)
         {
@@ -116,7 +116,7 @@ class StdPosixDirEntryRange: InputRange!(DirEntry)
         return 0;
     }
     
-    int opApply(int delegate(size_t, DirEntry) dg)
+    int opApply(scope int delegate(size_t, DirEntry) dg)
     {
         size_t i = 0;
         while(!_empty)

--- a/dlib/math/matrix.d
+++ b/dlib/math/matrix.d
@@ -56,6 +56,19 @@ import dlib.math.linsolve;
  */
 struct Matrix(T, size_t N)
 {
+    /**
+     * Compare two matrices.
+     *
+     * Params:
+     *     that = The matrix to compare with.
+     *
+     * Returns: $(D_KEYWORD true) if dimensions are equal, $(D_KEYWORD false) otherwise.
+     */
+    bool opEquals(Matrix!(T, N) that)
+    {
+        return arrayof == that.arrayof;
+    }
+
    /*
     * Return zero matrix
     */

--- a/dlib/memory/mmappool.d
+++ b/dlib/memory/mmappool.d
@@ -291,7 +291,7 @@ class MmapPool : Allocator
     }
 
     ///
-    @nogc @safe nothrow unittest
+    @nogc nothrow unittest
     {
         void[] p;
         MmapPool.instance.reallocate(p, 10 * int.sizeof);

--- a/dlib/text/lexer.d
+++ b/dlib/text/lexer.d
@@ -253,7 +253,7 @@ class Lexer: InputRange!(dchar[])
         return _front;
     }
 
-    final int opApply(int delegate(dchar[]) dg)
+    final int opApply(scope int delegate(dchar[]) dg)
     {
         int result = 0;
 
@@ -272,7 +272,7 @@ class Lexer: InputRange!(dchar[])
         return result;
     }
 
-    final int opApply(int delegate(size_t, dchar[]) dg)
+    final int opApply(scope int delegate(size_t, dchar[]) dg)
     {
         int result = 0;
         size_t i = 0;

--- a/dlib/text/slicelexer.d
+++ b/dlib/text/slicelexer.d
@@ -298,7 +298,7 @@ class SliceLexer: InputRange!string
         return _front;
     }
 
-    int opApply(int delegate(string) dg)
+    int opApply(scope int delegate(string) dg)
     {
         int result = 0;
 
@@ -317,7 +317,7 @@ class SliceLexer: InputRange!string
         return result;
     }
 
-    int opApply(int delegate(size_t, string) dg)
+    int opApply(scope int delegate(size_t, string) dg)
     {
         int result = 0;
         size_t i = 0;


### PR DESCRIPTION
* `InputRange.opApply` has now a signature with a scope delegate, so the compiler complains, that opApply isn't implemented.
* dlib.math.matrix test failed for a some weired reason:
```d
    auto m4 = matrixf(
        0, 3, 2,
        1, 0, 8,
        0, 1, 0
    );

    assert(m4.inverse == matrixf(
        -4,   1, 12,
        -0,   0,  1,
         0.5, 0, -1.5)
    );
```
If I replaced in the bottom matrix -0 with -0.0 and one 0 with -0.0, it passed (maybe compiler bug). Instead of hacking the unit tests I implemented opEquals which compares the internal representation arrays.
* Phobos function to get file creation time returns now a more exact value than dlib (with fraction seconds). So I adjusted the test case.
* I made dlib.network.url.URL to a template, because I had the problem that it can't work with char[].