### PR TITLE
Epoll fix

### DIFF
--- a/dlib/async/event/epoll.d
+++ b/dlib/async/event/epoll.d
@@ -146,6 +146,7 @@ class EpollLoop : SelectorLoop
             else if (events[i].events & EPOLLERR)
             {
                 kill(io, null);
+                continue;
             }
             else if (events[i].events & (EPOLLIN | EPOLLPRI | EPOLLHUP))
             {
@@ -170,13 +171,14 @@ class EpollLoop : SelectorLoop
                 if (transport.socket.disconnected)
                 {
                     kill(io, exception);
+                    continue;
                 }
                 else if (io.output.length)
                 {
                     swapPendings.insertBack(io);
                 }
             }
-            else if (events[i].events & EPOLLOUT)
+            if (events[i].events & EPOLLOUT)
             {
                 auto transport = cast(SelectorStreamTransport) io.transport;
                 assert(transport !is null);

--- a/dlib/network/url.d
+++ b/dlib/network/url.d
@@ -651,6 +651,9 @@ static this()
 
 /**
  * A Unique Resource Locator.
+ *
+ * Params:
+ *     U = URL string type.
  */
 struct URL(U = string)
     if (isSomeString!U)
@@ -1116,18 +1119,12 @@ enum Component : string
  * Params:
  *     T      = $(D_SYMBOL Component) member or $(D_KEYWORD null) for a
  *              struct with all components.
+ *     U      = URL string type.
  *     source = The string containing the URL.
  *
- * Returns: Requested URL components.
+ * Returns: Requested URL component(s).
  */
-URL parseURL(U)(in U source)
-    if (isSomeString!U)
-{
-    return URL!U(source);
-}
-
-/** ditto */
-string parseURL(string T, U)(in U source)
+U parseURL(string T, U)(in U source)
     if ((T == "scheme"
       || T =="host"
       || T == "user"
@@ -1141,6 +1138,13 @@ string parseURL(string T, U)(in U source)
 }
 
 /** ditto */
+auto parseURL(U)(in U source)
+    if (isSomeString!U)
+{
+    return URL!U(source);
+}
+
+/** ditto */
 ushort parseURL(string T, U)(in U source)
     if (T == "port" && isSomeString!U)
 {
@@ -1151,6 +1155,9 @@ ushort parseURL(string T, U)(in U source)
 unittest
 {
     assert(parseURL!(Component.port)("http://example.org:5326") == 5326);
+
+    immutable dstring url = "http://example.org:5326";
+    static assert(is(typeof(parseURL(url)) == URL!dstring));
 }
 
 private unittest


### PR DESCRIPTION
Here is a fix for the event loop (epoll on linux) and fix related to my last change of dlib.network.url.parseURL (I had wrong return types).