### PR TITLE
Fix modification time test when higher precision is used on linux

### DIFF
--- a/dlib/filesystem/local.d
+++ b/dlib/filesystem/local.d
@@ -124,7 +124,12 @@ class LocalFileSystem : FileSystem {
 
             stat_out.sizeInBytes = st.st_size;
             stat_out.creationTimestamp = SysTime(unixTimeToStdTime(st.st_ctime));
-            stat_out.modificationTimestamp = SysTime(unixTimeToStdTime(st.st_mtime));
+            auto modificationStdTime = unixTimeToStdTime(st.st_mtime);
+            static if (is(typeof(st.st_mtimensec)))
+            {
+                modificationStdTime += st.st_mtimensec / 100;
+            }
+            stat_out.modificationTimestamp = SysTime(modificationStdTime);
 
             return true;
         }


### PR DESCRIPTION
Tests failed on my machine because phobos used higher precision for modification time.
Note that this may fail on other platform too.
To be sure we need to copy and use the whole function https://github.com/dlang/phobos/blob/0a434259c07bfb8c49e1694e54c7762f61f69918/std/file.d#L936 but I'm not really comfortable with such copy-pasting. What do you think?

Other possible solution is to remove fractional seconds before comparison in unittest.