### PR TITLE
Reorder COPYING file, so that license name is the first line

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,8 +1,8 @@
+Boost Software License - Version 1.0 - August 17th, 2003
+
 Copyright (c) 2011-2018 Timur Gafarov, Martin Cejp, Andrey Penechko, Vadim Lopatin,
 Nick Papanastasiou, Oleg Baharev, Roman Chistokhodov, Eugene Wissner, Roman Vlasov, 
 Basile Burg, Valeriy Fedotov.
-
-Boost Software License - Version 1.0 - August 17th, 2003
 
 Permission is hereby granted, free of charge, to any person or organization
 obtaining a copy of the software and accompanying documentation covered by


### PR DESCRIPTION
This way github will show the repository license correctly.
Like:
![image](https://user-images.githubusercontent.com/1129910/46312527-fa1d6c80-c5cd-11e8-925d-d66c4a47bd4a.png)
instead of:
![image](https://user-images.githubusercontent.com/1129910/46312543-0acde280-c5ce-11e8-8e9f-14374aa30d57.png)

