### PR TITLE
Use `version(linux)` instead of `version(Linux)`

### DIFF
--- a/dlib/filesystem/posix/common.d
+++ b/dlib/filesystem/posix/common.d
@@ -40,7 +40,7 @@ version(Posix)
     }
 
     // Rename stat to stat_ because of method name collision
-    version(Linux)
+    version(linux)
     {
         alias off_t = off64_t;
         alias stat_t = stat64_t;


### PR DESCRIPTION
`version(Linux)` is not defined by the D runtime, so any assumptions about the defined types are mislead.

I assume this was an accident, although an honest mistake since all other OS version start with a capital letter.