### PR TITLE
lookAtMatrix: assertion added

### DIFF
--- a/dlib/math/transformation.d
+++ b/dlib/math/transformation.d
@@ -417,6 +417,7 @@ do
     auto f = (center - eye).normalized;
     auto u = (up).normalized;
     auto s = cross(f, u).normalized;
+    assert(!s.isAlmostZero, "look direction cannot be exactly parallel to the up direction");
     u = cross(s, f);
 
     Result[0,0] = s.x;


### PR DESCRIPTION
Unexpectedly discovered that this function not works at all cases: it may fail at any moment if directions of the up vectors and direction of the view vector (from eye to center point) coincide

I think that this ~~drawback~~ must be somehow remarked (by assertion) because complete absence of an image on resulting frame confuses

~~I suspect there must be some other way to define a view matrix? Maybe, lookAtMatrix concept is outdated?~~
upd: Yes, I figured out that the upward vector should be relative to the camera